### PR TITLE
Handle Thread.interrupt in case of falling into infinite loop

### DIFF
--- a/math/src/test/java/math/optim/BFGSSpec.java
+++ b/math/src/test/java/math/optim/BFGSSpec.java
@@ -8,7 +8,7 @@ import math.linear.doubles.Vector;
 public final class BFGSSpec {
   
   @Test
-  public void testBFGS() {
+  public void testBFGS() throws InterruptedException {
     AbstractMultivariateFunction f = new RosenbrockFunction();
     Vector startingPoint = new Vector(0.5, 1.5);
     final double tol = 1E-8;

--- a/timeseries/src/main/java/timeseries/models/arima/Arima.java
+++ b/timeseries/src/main/java/timeseries/models/arima/Arima.java
@@ -42,7 +42,7 @@ public interface Arima extends Model {
      *
      * @return a new ARIMA model from the given observations and model order.
      */
-    static Arima model(TimeSeries observations, ArimaOrder order) {
+    static Arima model(TimeSeries observations, ArimaOrder order) throws InterruptedException {
         return new ArimaModel(observations, order, TimePeriod.oneYear(), FittingStrategy.CSSML);
     }
 
@@ -58,7 +58,7 @@ public interface Arima extends Model {
      *
      * @return a new ARIMA model from the given observations, model order, and seasonal cycle.
      */
-    static Arima model(TimeSeries observations, ArimaOrder order, TimePeriod seasonalCycle) {
+    static Arima model(TimeSeries observations, ArimaOrder order, TimePeriod seasonalCycle) throws InterruptedException {
         return new ArimaModel(observations, order, seasonalCycle, FittingStrategy.CSSML);
     }
 
@@ -74,7 +74,7 @@ public interface Arima extends Model {
      *
      * @return a new ARIMA model from the given observations, model order, and fitting strategy.
      */
-    static Arima model(TimeSeries observations, ArimaOrder order, FittingStrategy fittingStrategy) {
+    static Arima model(TimeSeries observations, ArimaOrder order, FittingStrategy fittingStrategy) throws InterruptedException {
         return new ArimaModel(observations, order, TimePeriod.oneYear(), fittingStrategy);
     }
 
@@ -93,7 +93,7 @@ public interface Arima extends Model {
      * @return a new ARIMA model from the given observations, model order, seasonal cycle, and fitting strategy.
      */
     static Arima model(TimeSeries observations, ArimaOrder order, TimePeriod seasonalCycle,
-                            FittingStrategy fittingStrategy) {
+                            FittingStrategy fittingStrategy) throws InterruptedException {
         return new ArimaModel(observations, order, seasonalCycle, fittingStrategy);
     }
 

--- a/timeseries/src/main/java/timeseries/models/arima/ArimaModel.java
+++ b/timeseries/src/main/java/timeseries/models/arima/ArimaModel.java
@@ -80,12 +80,12 @@ final class ArimaModel implements Arima {
     private final double[] stdErrors;
 
     ArimaModel(final TimeSeries observations, final ArimaOrder order, final TimePeriod seasonalCycle,
-               final FittingStrategy fittingStrategy) {
+               final FittingStrategy fittingStrategy) throws InterruptedException {
         this(observations, order, seasonalCycle, fittingStrategy, null);
     }
 
     private ArimaModel(final TimeSeries observations, final ArimaOrder order, final TimePeriod seasonalCycle,
-                       final FittingStrategy fittingStrategy, LinearRegressionModel regression) {
+                       final FittingStrategy fittingStrategy, LinearRegressionModel regression) throws InterruptedException {
         this.observations = observations;
         this.order = order;
         this.fittingStrategy = fittingStrategy;

--- a/timeseries/src/test/java/timeseries/models/arima/ArimaSpec.java
+++ b/timeseries/src/test/java/timeseries/models/arima/ArimaSpec.java
@@ -44,7 +44,7 @@ public class ArimaSpec {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void whenZerosThenFittedAreZero() {
+    public void whenZerosThenFittedAreZero() throws InterruptedException {
         TimeSeries timeSeries = new TimeSeries(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         double[] expected = new double[timeSeries.size()];
         ArimaOrder order = ArimaOrder.order(1, 0, 1, 0, 0, 0, Constant.INCLUDE);
@@ -137,7 +137,7 @@ public class ArimaSpec {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
+    public void testEqualsAndHashCode() throws InterruptedException {
         TimeSeries series = TestData.livestock;
         ArimaOrder order = ArimaOrder.order(1, 1, 1);
         ArimaOrder order2 = ArimaOrder.order(1, 0, 1, Constant.INCLUDE);


### PR DESCRIPTION
When grid searching over many parameters sometimes loops in BFGS class
will never terminate.

Perhaps loops at BFGS#124 should scale the step up if change sign
keeps the same?

For now I add Thread.interruption handler so clients code can
gracefully stop code from running when it runs into infinite loop.